### PR TITLE
Grouped tests execution using setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ To execute the project
     python3 translator/Translator.py [input-file] [robot]
     python3 translator/Translator.py [input-file] [robot] [architecture-file]
 ```
+To execute the tests
+``` 
+    python3 setup.py test
+```
+
 ## Robots supported
 * [Complubot](https://www.arduino.cc/en/Guide/Robot) (Arduino Robot)
 * [MBot](https://www.makeblock.com/steam-kits/mbot)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+from distutils.cmd import Command
+from distutils.core import setup
+    
+setup(author='Shubhanshu Agarwal',
+      author_email='agarwal.shubhanshu07@gmail.com',
+      license='MIT',
+     
+      zip_safe=False,
+      test_suite ='tests.Examples_tests'
+)

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,4 @@ from setuptools import setup
 from distutils.cmd import Command
 from distutils.core import setup
     
-setup(author='Shubhanshu Agarwal',
-      author_email='agarwal.shubhanshu07@gmail.com',
-      license='MIT',
-     
-      zip_safe=False,
-      test_suite ='tests.Examples_tests'
-)
+setup(test_suite ='tests.Examples_tests')

--- a/tests/ComplubotExamplesTests.py
+++ b/tests/ComplubotExamplesTests.py
@@ -1,4 +1,5 @@
 import ast
+
 import unittest
 import translator.Translator as translator
 
@@ -17,7 +18,7 @@ class ComplubotExamplesTests(unittest.TestCase):
         translator.strings = strings
         translator.robot = 'ComplubotControl'
         translator.robot_architecture = ''
-        vars.halduino_directory = '../HALduino/halduino'
+        vars.halduino_directory = 'HALduino/halduino'
         visitor = translator.TranslatorVisitor()
 
     def translate_string(self, text):

--- a/tests/MBotExamplesTest.py
+++ b/tests/MBotExamplesTest.py
@@ -15,9 +15,9 @@ class MBotExamplesTests(unittest.TestCase):
         vars.Variables()
         translator.vars = vars
         translator.strings = strings
-        translator.robot = 'mBot'
+        translator.robot = 'MBot'
         translator.robot_architecture = ''
-        vars.halduino_directory = '../HALduino/halduino'
+        vars.halduino_directory = 'HALduino/halduino'
         visitor = translator.TranslatorVisitor()
 
     def translate_string(self, text):

--- a/tests/SergioRobotExampleTests.py
+++ b/tests/SergioRobotExampleTests.py
@@ -15,7 +15,7 @@ class SergioExamplesTests(unittest.TestCase):
         vars.Variables()
         translator.vars = vars
         translator.strings = strings
-        vars.halduino_directory = '../HALduino/halduino'
+        vars.halduino_directory = 'HALduino/halduino'
         translator.robot_architecture = ''
         translator.robot = 'SergioRobot'
         visitor = translator.TranslatorVisitor()

--- a/tests/TranslatorTests.py
+++ b/tests/TranslatorTests.py
@@ -17,7 +17,7 @@ class TranslatorTests(unittest.TestCase):
         translator.strings = strings
         translator.robot = 'ComplubotControl'
         translator.robot_architecture = ''
-        vars.halduino_directory = '../HALduino/halduino'
+        vars.halduino_directory = 'HALduino/halduino'
         visitor = translator.TranslatorVisitor()
 
     def translate_string(self, text):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,16 @@
+import unittest
+from . import ComplubotExamplesTests
+from . import SergioRobotExampleTests
+from . import MBotExamplesTest
+from . import TranslatorTests
+
+def Examples_tests():
+	test_to_run=[ComplubotExamplesTests,SergioRobotExampleTests,MBotExamplesTest,TranslatorTests]
+	loader = unittest.TestLoader()
+	suite_list=[]
+	for test in test_to_run:
+		suite = loader.loadTestsFromModule(test)
+		suite_list.append(suite)
+	
+	big_suite = unittest.TestSuite(suite_list)
+	return big_suite	

--- a/translator/Translator.py
+++ b/translator/Translator.py
@@ -690,7 +690,7 @@ if __name__ == "__main__":
 }\n'''
 
     variables_manager = ''
-    for line in open('Halduino/variablesManager.ino', 'r'):
+    for line in open('HALduino/variablesManager.ino', 'r'):
         if re.search('#include', line):
             vars.libraries[line] = line
         else:


### PR DESCRIPTION
[Bug fixes and enhancements]

This PR makes the following changes:
1. Adds `setup.py` in the root of the repository to allow packaging and execution of tests using a single file. The tests can now be executed using:
```shell
python3 setup.py test
```
2. Fix all the path errors across the repository which lead to examples failing to execute.

Grouping tests allows easier for execution and future support for Continous Integration tools.